### PR TITLE
221 feature pre pushのテスト実行時にfirebaseエミュレーターを起動するようにする

### DIFF
--- a/apps/api/src/config/environments/env.service.ts
+++ b/apps/api/src/config/environments/env.service.ts
@@ -32,7 +32,7 @@ export class Env {
 
         ...(runtimeEnv.APP_ENV !== 'production' && {
           // これが設定されていると、自動的にfirebase-adminの初期化時にemulatorを使うようになる
-          FIREBASE_AUTH_EMULATOR_HOST: z.string().url().nullable(),
+          FIREBASE_AUTH_EMULATOR_HOST: z.string().nullable(),
         }),
       },
       clientPrefix: '',

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -41,8 +41,8 @@ module.exports = {
     },
     test: {
       default: `nps test.web test.api`,
-      web: `cd ${webPath} && yarn test`,
-      api: `cd ${apiPath} && yarn test`,
+      web: `cd ${fbToolsPath} && firebase emulators:exec "nps firebase.admin & cd ${webPath} && yarn test && nps util.pkill.fbadmin"`,
+      api: `cd ${apiPath} && yarn test`, // まだfirebase emulator不要 あとから必要になるかもしれない
       predredd: `docker compose up -d && npx turbo run dev --scope=fb-tools --scope=api --parallel --no-daemon`,
       ci: {
         default: `nps test.ci.web test.ci.api`,
@@ -141,6 +141,7 @@ module.exports = {
       gensec: `node ${root('tool/gen-secret.js')}`,
       pkill: {
         api: `node ${root('tool/process-kill.js')} 3000`,
+        fbadmin: `node ${root('tool/process-kill.js')} 3010`,
       },
     },
   },


### PR DESCRIPTION
## Pull Request Template

### Issues

<!-- 関連するIssueを記載してください。例: #123 -->
#221 
---

### Subject

<!-- 何をしたのか、箇条書きで記述してください。 -->

---

### Body

<!-- 変更内容の詳細、背景、意図など、詳しく記述してください。 -->
以下のような内容で赤色のメッセージが出るが、それで正常
```
nps is executing `util.pkill.fbadmin` : node /Users/waonpad/dev/miraisozoten/tool/process-kill.js 3010
Killed process on port 3010
Done
/bin/sh: line 1:  4797 Killed: 9               node lib/admin-server.js
The script called "firebase.admin" which runs "cd /Users/waonpad/dev/miraisozoten/packages/fb-tools && node lib/admin-server.js" failed with exit code 137 https://github.com/sezna/nps/blob/master/other/ERRORS_AND_WARNINGS.md#failed-with-exit-code
```
---

### Breaking Changes

<!-- 重要な変更点や、他の部分に影響を及ぼす可能性のある変更があれば記述してください。 -->

---

### Additional Notes

<!-- その他、関連する情報や注意点などがあれば記述してください。 -->
